### PR TITLE
Allow date format ordering other than d-m-y

### DIFF
--- a/assets/components/daterangetv/mgr/js/daterangetv.renderer.js
+++ b/assets/components/daterangetv/mgr/js/daterangetv.renderer.js
@@ -11,23 +11,53 @@ DaterangeTV.Renderer = function (value) {
         return '';
     }
 
-    var data = value.split('||');
-    var start = (data.length >= 1) ? new Date(data[0]) : false;
-    var end = (data.length >= 2) ? new Date(data[1]) : false;
-    var format = MODx.config['daterangetv.manager_format'].split('|');
-    var separator = MODx.config['daterangetv.separator'];
-    var result = '';
-
+    var data = value.split('||'),
+        start = (data.length >= 1) ? new Date(data[0]) : false,
+        end = (data.length >= 2) ? new Date(data[1]) : false,
+        format = MODx.config['daterangetv.manager_format'].split('|'),
+        separator = MODx.config['daterangetv.separator'],
+        dayPos = MODx.config['daterangetv.manager_format'].search(/d|D|j|l|N|S|w|z/),
+        monthPos = MODx.config['daterangetv.manager_format'].search(/F|m|M|n|t/),
+        daysBeforeMonths = monthPos > dayPos ? true : false,
+        yearsFirst = monthPos === 0 || dayPos === 0 ? false : true,
+        result = '';
+    
+    if(dayPos === -1){ 
+        console.log('A valid DAY format has not been specified or an incorrect syntax was used in MODx\'s daterangetv.manager_format system setting. See php date function documentation for correct formats.'); 
+    }
+    if(monthPos === -1){ 
+        console.log('A valid MONTH format has not been specified or an incorrect syntax was used in MODx\'s daterangetv.manager_format system setting. See php date function documentation for correct formats.'); 
+    }
+    
+    if(start){ start = new Date(start.getUTCFullYear(),start.getUTCMonth(),start.getUTCDate()); }
+    if(end){ end = new Date(end.getUTCFullYear(),end.getUTCMonth(),end.getUTCDate()); }
+    
     if (start && start.getTime() === start.getTime()) {
         if (end && end.getTime() === end.getTime()) {
             if (start.getFullYear() != end.getFullYear()) {
                 result = Ext.util.Format.date(start, format[0] + format[1] + format[2]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
             } else {
                 if (start.getMonth() != end.getMonth()) {
-                    result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
+                    if (yearsFirst){
+                        result = Ext.util.Format.date(start, format[0] + format[1] + format[2]) + separator + Ext.util.Format.date(end, format[1] + format[2]);
+                    } else {
+                        result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
+                    }
                 } else {
                     if (start.getDay() != end.getDay()) {
-                        result = Ext.util.Format.date(start, format[0]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
+                        if (yearsFirst){
+                            if(daysBeforeMonths){
+                                result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[1] + format[2]);
+                            } else {
+                                result = Ext.util.Format.date(start, format[0] + format[1] + format[2]) + separator + Ext.util.Format.date(end, format[2]);
+                            }
+                        } else {
+                            if(daysBeforeMonths){
+                                result = Ext.util.Format.date(start, format[0]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
+                            } else {
+                                result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[1] + format[2]);
+                            }
+                        }
                     } else {
                         result = Ext.util.Format.date(start, format[0] + format[1] + format[2]);
                     }

--- a/assets/components/daterangetv/mgr/js/daterangetv.renderer.js
+++ b/assets/components/daterangetv/mgr/js/daterangetv.renderer.js
@@ -44,7 +44,7 @@ DaterangeTV.Renderer = function (value) {
                         result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[0] + format[1] + format[2]);
                     }
                 } else {
-                    if (start.getDay() != end.getDay()) {
+                    if (start.getDate() != end.getDate()) {
                         if (yearsFirst){
                             if(daysBeforeMonths){
                                 result = Ext.util.Format.date(start, format[0] + format[1]) + separator + Ext.util.Format.date(end, format[1] + format[2]);

--- a/core/components/daterangetv/model/daterangetv/daterangetv.class.php
+++ b/core/components/daterangetv/model/daterangetv/daterangetv.class.php
@@ -24,7 +24,7 @@ class DaterangeTV
      * The version
      * @var string $version
      */
-    public $version = '1.2.2';
+    public $version = '1.2.0';
 
     /**
      * The class options
@@ -116,18 +116,35 @@ class DaterangeTV
     public function getDaterange($value, $properties = array())
     {
         $format = $this->getOption('format', $properties);
+        $format_trimmed = trim(str_replace('%', '', $format));
+        
+        if(preg_match('/(a|A|d|e|j|u|w)/', $format_trimmed, $dayformat, PREG_OFFSET_CAPTURE)===1){
+            $dayPos = $dayformat[0][1];
+        }
+        if(preg_match('/(b|B|h|m)/', $format_trimmed, $monthformat, PREG_OFFSET_CAPTURE)===1){
+            $monthPos = $monthformat[0][1];
+        }
+        
+        $daysBeforeMonths = $monthPos > $dayPos ? true : false ;
+        $yearsFirst = $monthPos === 0 || $dayPos === 0 ? false : true ;
+
         $separator = $this->getOption('separator', $properties);
         $locale = $this->getOption('locale', $properties, false);
-
+        
         $format = explode('|', $format);
+        
+        /*
+        // @smg6511: not sure how this would result in a different array than above...
         if (count($format) != 3) {
             $format = explode('|', $this->getOption('format'));
         }
+        */
 
         // get value
         $daterange = explode('||', $value);
-        $daterange[0] = (isset($daterange[0]) && $daterange[0] != '') ? intval(strtotime($daterange[0])) : 0;
-        $daterange[1] = (isset($daterange[1]) && $daterange[1] != '') ? intval(strtotime($daterange[1])) : 0;
+        $start = (isset($daterange[0]) && $daterange[0] != '') ? intval(strtotime($daterange[0])) : 0;
+        $end = (isset($daterange[1]) && $daterange[1] != '') ? intval(strtotime($daterange[1])) : 0;
+        $result = '';
 
         // set locale
         if ($locale) {
@@ -138,29 +155,42 @@ class DaterangeTV
         }
 
         // calculate daterange output
-        if (intval($daterange[1]) > intval($daterange[0])) {
-            $end = trim(strftime($format[0] . $format[1] . $format[2], $daterange[1]));
+        if (intval($end) > intval($start)) {
+            $start_day = date('d', $start);
+            $start_month = date('m', $start);
+            $start_year = date('Y', $start);
 
-            $start_day = date('d', $daterange[0]);
-            $start_month = date('m', $daterange[0]);
-            $start_year = date('Y', $daterange[0]);
-
-            $end_day = date('d', $daterange[1]);
-            $end_month = date('m', $daterange[1]);
-            $end_year = date('Y', $daterange[1]);
+            $end_day = date('d', $end);
+            $end_month = date('m', $end);
+            $end_year = date('Y', $end);
 
             if ($start_year != $end_year) {
-                $start = trim(strftime($format[0] . $format[1] . $format[2], $daterange[0])) . $separator;
+                $result  = trim(strftime($format[0] . $format[1] . $format[2], $start)) . $separator . trim(strftime($format[0] . $format[1] . $format[2], $end));
             } elseif ($start_month != $end_month) {
-                $start = trim(strftime($format[0] . $format[1], $daterange[0])) . $separator;
+                if ($yearsFirst){
+                    $result = trim(strftime($format[0] . $format[1] . $format[2], $start)) . $separator . trim(strftime($format[1] . $format[2], $end));
+                } else {
+                    $result = trim(strftime($format[0] . $format[1], $start)) . $separator . trim(strftime($format[0] . $format[1] . $format[2], $end));
+                }
             } elseif ($start_day != $end_day) {
-                $start = trim(strftime($format[0], $daterange[0])) . $separator;
+                if ($yearsFirst){
+                    if ($daysBeforeMonths){
+                        $result = trim(strftime($format[0] . $format[1], $start)) . $separator . trim(strftime($format[1] . $format[2], $end));
+                    } else {
+                        $result = trim(strftime($format[0] . $format[1] . $format[2], $start)) . $separator . trim(strftime($format[2], $end));
+                    }
+                } else {
+                    if ($daysBeforeMonths){
+                        $result = trim(strftime($format[0], $start)) . $separator . trim(strftime($format[0] . $format[1] . $format[2], $end));
+                    } else {
+                       $result = trim(strftime($format[0] . $format[1], $start)) . $separator . trim(strftime($format[1] . $format[2], $end)); 
+                    }
+                }
             } else {
-                $start = '';
+                $result = trim(strftime($format[0] . $format[1] . $format[2], $start));
             }
-            $output = $start . $end;
         } else {
-            $output = trim(strftime($format[0] . $format[1] . $format[2], $daterange[0]));
+            $result = trim(strftime($format[0] . $format[1] . $format[2], $start));
         }
 
         // reset locale
@@ -169,6 +199,6 @@ class DaterangeTV
                 $this->modx->log(modX::LOG_LEVEL_DEBUG, 'DaterangeTV: Old locale ' . $currentLocale . 'not valid!');
             }
         }
-        return ($output);
+        return ($result);
     }
 }

--- a/core/components/daterangetv/model/daterangetv/daterangetv.class.php
+++ b/core/components/daterangetv/model/daterangetv/daterangetv.class.php
@@ -117,15 +117,21 @@ class DaterangeTV
     {
         $format = $this->getOption('format', $properties);
         $format_trimmed = trim(str_replace('%', '', $format));
+        $dayPos = false;
+        $monthPos = false;
         
         if(preg_match('/(a|A|d|e|j|u|w)/', $format_trimmed, $dayformat, PREG_OFFSET_CAPTURE)===1){
             $dayPos = $dayformat[0][1];
+        } else {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'A valid strftime DAY format has not been specified or an incorrect syntax was used.');
         }
         if(preg_match('/(b|B|h|m)/', $format_trimmed, $monthformat, PREG_OFFSET_CAPTURE)===1){
             $monthPos = $monthformat[0][1];
+        } else {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'A valid strftime MONTH format has not been specified or an incorrect syntax was used.');
         }
         
-        $daysBeforeMonths = $monthPos > $dayPos ? true : false ;
+        $daysBeforeMonths = $dayPos !== false && $monthPos !== false && ($monthPos > $dayPos) ? true : false ;
         $yearsFirst = $monthPos === 0 || $dayPos === 0 ? false : true ;
 
         $separator = $this->getOption('separator', $properties);

--- a/core/components/daterangetv/model/daterangetv/daterangetv.class.php
+++ b/core/components/daterangetv/model/daterangetv/daterangetv.class.php
@@ -24,7 +24,7 @@ class DaterangeTV
      * The version
      * @var string $version
      */
-    public $version = '1.2.0';
+    public $version = '1.2.2';
 
     /**
      * The class options


### PR DESCRIPTION
Proposed changes add m-d-y, y-d-m, and y-m-d ordering in the back end renderer and front end snippet (via changes to the main class). Also, getUTC\* functions used in renderer to ensure generated date is zero-hour in any timezone.
